### PR TITLE
Set up plaid backend and frontend proxy

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -1,6 +1,73 @@
+// read env vars from .env file. Access variables in .env by 'process.env.MY_VARIABLE_NAME'
+require("dotenv").config({ silent: true })
+const { Configuration, PlaidApi, PlaidEnvironments } = require('plaid')
 // import and instantiate express
-const express = require("express") // CommonJS import style!
-const app = express() // instantiate an Express object
-// we will put some server logic here later...
+const express = require("express") 
+// instantiate an Express object
+const app = express() 
+const PLAID_CLIENT_ID = process.env.PLAID_CLIENT_ID
+const PLAID_SECRET = process.env.PLAID_SECRET
+const PLAID_ENV = process.env.PLAID_ENV || 'sandbox'
+
+// PLAID_PRODUCTS is a comma-separated list of products to use when initializing
+// Link. Note that this list must contain 'assets' in order for the app to be
+// able to create and retrieve asset reports.
+const PLAID_PRODUCTS = (process.env.PLAID_PRODUCTS || 'transactions').split(
+  ',',
+)
+
+// PLAID_COUNTRY_CODES is a comma-separated list of countries for which users
+// will be able to select institutions from.
+const PLAID_COUNTRY_CODES = (process.env.PLAID_COUNTRY_CODES || 'US').split(
+  ',',
+)
+
+// Parameters used for the OAuth redirect Link flow.
+// Set PLAID_REDIRECT_URI to 'http://localhost:3000'
+// The OAuth redirect flow requires an endpoint on the developer's website
+// that the bank website should redirect to. You will need to configure
+// this redirect URI for your client ID through the Plaid developer dashboard
+// at https://dashboard.plaid.com/team/api.
+const PLAID_REDIRECT_URI = process.env.PLAID_REDIRECT_URI || ''
+
+// We store the access_token in memory - in production, store it in a secure
+// persistent data store
+let ACCESS_TOKEN = null
+let PUBLIC_TOKEN = null
+let ITEM_ID = null
+// The payment_id is only relevant for the UK Payment Initiation product.
+// We store the payment_id in memory - in production, store it in a secure
+// persistent data store
+let PAYMENT_ID = null
+
+// Initialize the Plaid client
+const configuration = new Configuration({
+  basePath: PlaidEnvironments[PLAID_ENV],
+  baseOptions: {
+    headers: {
+      'PLAID-CLIENT-ID': PLAID_CLIENT_ID,
+      'PLAID-SECRET': PLAID_SECRET,
+      'Plaid-Version': '2020-09-14',
+    },
+  },
+})
+
+const plaidClient = new PlaidApi(configuration)
+
+// middleware for parsing incoming POST data
+app.use(express.json()) // decode JSON-formatted incoming POST data
+app.use(express.urlencoded({ extended: true })) // decode url-encoded incoming POST data
+
+// function to get categories from Plaid
+app.get('/api/categories', async (req, resp) => {
+    try {
+        const response = await plaidClient.categoriesGet({})
+        const categories = response.data.categories
+        console.log(categories)
+        resp.json(categories)
+    } catch (error) {
+        console.log(error.response.data)
+    }
+})
 // export the express app we created to make it available to other modules
 module.exports = app

--- a/back-end/package-lock.json
+++ b/back-end/package-lock.json
@@ -73,6 +73,14 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "requires": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -356,6 +364,11 @@
         "is-obj": "^2.0.0"
       }
     },
+    "dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -462,6 +475,11 @@
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
       }
+    },
+    "follow-redirects": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
+      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
     },
     "forwarded": {
       "version": "0.2.0",
@@ -923,6 +941,14 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
+    },
+    "plaid": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/plaid/-/plaid-9.5.0.tgz",
+      "integrity": "sha512-Z4egAaRnOQ3+gfo1nPTH5/WU1x8KXiBdxzxHJr0BLFtXlgguN7RGmwm+jDXKxhRe/DsFsEI8BHr7Ogu5vhSFMg==",
+      "requires": {
+        "axios": "0.21.4"
+      }
     },
     "prepend-http": {
       "version": "2.0.0",

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -9,7 +9,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.17.1"
+    "dotenv": "^10.0.0",
+    "express": "^4.17.1",
+    "plaid": "^9.5.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.14"

--- a/back-end/server.js
+++ b/back-end/server.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 const server = require("./app") // load up the web server
-const port = 3000 // the port to listen to for incoming requests
+const port = 5000 // the port to listen to for incoming requests
 // call express's listen function to start listening to the port
 const listener = server.listen(port, function () {
   console.log(`Server running on port: ${port}`)

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -48,5 +48,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "proxy": "http://localhost:5000"
 }

--- a/front-end/src/components/Categories/CategoryList.js
+++ b/front-end/src/components/Categories/CategoryList.js
@@ -4,33 +4,20 @@ import '../css/CategoryList.css'
 import * as AiIcons from 'react-icons/ai'
 import * as MdIcons from 'react-icons/md'
 
-const baseURL = "http://localhost:3000/categories" 
-
 function CategoryList() {
     const [categoryList, setCategoryList] = useState(null)
 
     useEffect(() => {
-        axios.get(baseURL).then((resp) => {
+        axios.get('/api/categories').then((resp) => {
             setCategoryList(resp.data)
         }, () => {
             console.log(categoryList)
         })
-    })
+    }, [])
 
+    // TODO: complete mappings from category to icons 
     const mapCategoryToIcon = (category) => {
-        if(category === "Grocery") {
-            return <MdIcons.MdOutlineLocalGroceryStore />
-        } else if(category === "Transportation") {
-            return <MdIcons.MdEmojiTransportation />
-        } else if(category === "Cafe") {
-            return <MdIcons.MdOutlineLocalCafe />
-        } else if(category === "Home") {
-            return <AiIcons.AiOutlineHome />
-        } else if(category === "Education") {
-            return <MdIcons.MdOutlineCastForEducation />
-        } else if(category === "Leisure") {
-            return <MdIcons.MdOutlineSportsHandball />
-        }
+        return <MdIcons.MdOutlineLocalCafe />
     }
 
     return (
@@ -38,11 +25,9 @@ function CategoryList() {
             <ul>
                 {categoryList && categoryList.map((item, index) => {
                     return (
-                        <li key={index} className={item.cName}>
-                            {mapCategoryToIcon(item.title)}
-                            <span>
-                            {item.title}
-                            </span>
+                        <li key={index} className="category-list-text">
+                            {mapCategoryToIcon(item.hierarchy[0])}
+                            <span>{item.hierarchy[0]}</span>
                         </li>
                     );
                 })}


### PR DESCRIPTION
1. Set up backend for calling Plaid api 
2. Include an example function `app.get('/api/categories',...)` to illustrate how frontend invokes backend. 

Similar UI, but data comes from backend calling Plaid's API. 
![Screen Shot 2021-10-28 at 6 39 47 PM](https://user-images.githubusercontent.com/49820142/139346078-f73e426a-4a29-45d2-bafc-024e1e667715.png)


