### PR TITLE
Display bank details in details page

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -173,7 +173,7 @@ app.post('/api/get_bank_accounts', async (request, response, next) => {
     return response.json(constructAccountsArr(res.data.accounts));
   } catch (error) {
     console.log("ERROR:");
-    prettyPrintResponse(error.response)
+    prettyPrintResponse(error)
     return response.json({
       err: error
     })

--- a/front-end/src/components/AccountDetail/AccountDetail.js
+++ b/front-end/src/components/AccountDetail/AccountDetail.js
@@ -10,10 +10,12 @@ import "../css/AccountDetail.css";
  * @returns Details page for 1 bank account
  */
 function AccountDetail(props) {
+    console.log(props.bankDetails);
   return (
     <div>
-      <h1>{props.bankName}</h1>
-      <AccountDetailForm />
+      <h1>{props.bankDetails.name}</h1>
+      <h5>Available Balance: {props.bankDetails.balances.available} {props.bankDetails.balances.currency}</h5>
+      <h5>Current Balance: {props.bankDetails.balances.current} {props.bankDetails.balances.currency}</h5>
       <Button
         onClick={() => {
           props.showAccountDetail(false);
@@ -22,7 +24,7 @@ function AccountDetail(props) {
         variant="contained"
         id="save-details-btn"
       >
-        Save Details
+        Back
       </Button>
     </div>
   );

--- a/front-end/src/components/Accounts/AccountPanel.js
+++ b/front-end/src/components/Accounts/AccountPanel.js
@@ -33,10 +33,10 @@ const AccountPanel = (props) => {
           fullWidth={true}
           onClick={() => {
             props.showAccountDetail(true);
-            props.setBankDetailHeader(props.bankName);
+            props.setBankDetails(props.bankDetails);
           }}
         >
-          {props.bankName}
+          {props.bankDetails.name}
         </Button>
       </ButtonGroup>
     </div>

--- a/front-end/src/components/Accounts/AccountsPage.js
+++ b/front-end/src/components/Accounts/AccountsPage.js
@@ -83,11 +83,11 @@ function AccountsPage(props) {
         <h1>Accounts</h1>
         {bankData.map(bank => (
             <AccountPanel 
-                bankName={bank.name} 
+                bankDetails={bank} 
                 type={bank.type}
                 balances={bank.balances}
                 showAccountDetail={props.setShowDetail}
-                setBankDetailHeader={props.setBankDetailName}
+                setBankDetails={props.setBankDetails}
             />))}
 
         {token === null ? (

--- a/front-end/src/pages/Accounts.js
+++ b/front-end/src/pages/Accounts.js
@@ -18,19 +18,19 @@ function Accounts() {
   const { data: dataNullable, isLoaded } = useAsync(api.getAccountInfo, []);
   const data = dataNullable ?? [];
   const [showDetail, setShowDetail] = useState(false);
-  const [bankDetailName, setBankDetailName] = useState("");
+  const [bankDetails, setBankDetails] = useState("");
 
   const renderPage = showDetail ? (
     <AccountDetail
       showAccountDetail={setShowDetail}
-      setBankDetailHeader={setBankDetailName}
-      bankName={bankDetailName}
+      setBankDetailHeader={setBankDetails}
+      bankDetails={bankDetails}
     />
   ) : (
     <AccountsPage
       banks={data}
       setShowDetail={setShowDetail}
-      setBankDetailName={setBankDetailName}
+      setBankDetails={setBankDetails}
     />
   );
 

--- a/tatusqq
+++ b/tatusqq
@@ -1,0 +1,91 @@
+[1mdiff --git a/front-end/src/components/AccountDetail/AccountDetail.js b/front-end/src/components/AccountDetail/AccountDetail.js[m
+[1mindex e0c7f66..7c5abb2 100644[m
+[1m--- a/front-end/src/components/AccountDetail/AccountDetail.js[m
+[1m+++ b/front-end/src/components/AccountDetail/AccountDetail.js[m
+[36m@@ -10,10 +10,12 @@[m [mimport "../css/AccountDetail.css";[m
+  * @returns Details page for 1 bank account[m
+  */[m
+ function AccountDetail(props) {[m
+[32m+[m[32m    console.log(props.bankDetails);[m
+   return ([m
+     <div>[m
+[31m-      <h1>{props.bankName}</h1>[m
+[31m-      <AccountDetailForm />[m
+[32m+[m[32m      <h1>{props.bankDetails.name}</h1>[m
+[32m+[m[32m      <h5>Available Balance: {props.bankDetails.balances.available} {props.bankDetails.balances.currency}</h5>[m
+[32m+[m[32m      <h5>Current Balance: {props.bankDetails.balances.current} {props.bankDetails.balances.currency}</h5>[m
+       <Button[m
+         onClick={() => {[m
+           props.showAccountDetail(false);[m
+[36m@@ -22,7 +24,7 @@[m [mfunction AccountDetail(props) {[m
+         variant="contained"[m
+         id="save-details-btn"[m
+       >[m
+[31m-        Save Details[m
+[32m+[m[32m        Back[m
+       </Button>[m
+     </div>[m
+   );[m
+[1mdiff --git a/front-end/src/components/Accounts/AccountPanel.js b/front-end/src/components/Accounts/AccountPanel.js[m
+[1mindex b7c8618..f6e606e 100644[m
+[1m--- a/front-end/src/components/Accounts/AccountPanel.js[m
+[1m+++ b/front-end/src/components/Accounts/AccountPanel.js[m
+[36m@@ -33,10 +33,10 @@[m [mconst AccountPanel = (props) => {[m
+           fullWidth={true}[m
+           onClick={() => {[m
+             props.showAccountDetail(true);[m
+[31m-            props.setBankDetailHeader(props.bankName);[m
+[32m+[m[32m            props.setBankDetails(props.bankDetails);[m
+           }}[m
+         >[m
+[31m-          {props.bankName}[m
+[32m+[m[32m          {props.bankDetails.name}[m
+         </Button>[m
+       </ButtonGroup>[m
+     </div>[m
+[1mdiff --git a/front-end/src/components/Accounts/AccountsPage.js b/front-end/src/components/Accounts/AccountsPage.js[m
+[1mindex 8a9981d..2a217f7 100644[m
+[1m--- a/front-end/src/components/Accounts/AccountsPage.js[m
+[1m+++ b/front-end/src/components/Accounts/AccountsPage.js[m
+[36m@@ -83,11 +83,11 @@[m [mfunction AccountsPage(props) {[m
+         <h1>Accounts</h1>[m
+         {bankData.map(bank => ([m
+             <AccountPanel [m
+[31m-                bankName={bank.name} [m
+[32m+[m[32m                bankDetails={bank}[m[41m [m
+                 type={bank.type}[m
+                 balances={bank.balances}[m
+                 showAccountDetail={props.setShowDetail}[m
+[31m-                setBankDetailHeader={props.setBankDetailName}[m
+[32m+[m[32m                setBankDetails={props.setBankDetails}[m
+             />))}[m
+ [m
+         {token === null ? ([m
+[1mdiff --git a/front-end/src/pages/Accounts.js b/front-end/src/pages/Accounts.js[m
+[1mindex d3bebba..0f888a7 100644[m
+[1m--- a/front-end/src/pages/Accounts.js[m
+[1m+++ b/front-end/src/pages/Accounts.js[m
+[36m@@ -18,19 +18,19 @@[m [mfunction Accounts() {[m
+   const { data: dataNullable, isLoaded } = useAsync(api.getAccountInfo, []);[m
+   const data = dataNullable ?? [];[m
+   const [showDetail, setShowDetail] = useState(false);[m
+[31m-  const [bankDetailName, setBankDetailName] = useState("");[m
+[32m+[m[32m  const [bankDetails, setBankDetails] = useState("");[m
+ [m
+   const renderPage = showDetail ? ([m
+     <AccountDetail[m
+       showAccountDetail={setShowDetail}[m
+[31m-      setBankDetailHeader={setBankDetailName}[m
+[31m-      bankName={bankDetailName}[m
+[32m+[m[32m      setBankDetailHeader={setBankDetails}[m
+[32m+[m[32m      bankDetails={bankDetails}[m
+     />[m
+   ) : ([m
+     <AccountsPage[m
+       banks={data}[m
+       setShowDetail={setShowDetail}[m
+[31m-      setBankDetailName={setBankDetailName}[m
+[32m+[m[32m      setBankDetails={setBankDetails}[m
+     />[m
+   );[m
+ [m


### PR DESCRIPTION
Related to #58 

Previously, the details page was allowing for edits via a form. After discussion with Tomer 2 standups ago, we decided to change this page to display account details instead of enabling editing options. This page shows current balance, available balance, and currency used for the bank account.
![image](https://user-images.githubusercontent.com/55705423/140629877-c70bce10-5591-474e-aea1-d85266f080ba.png)
