### PR TITLE
Refactor functions and constants to import into app.js

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -17,6 +17,7 @@ const constructTransactionArr = require('./functions/constructTransactionArray')
 const prettyPrintResponse = require('./functions/prettyPrintResponse');
 const formatError = require('./functions/formatError');
 const postAccessTokenToDatabase = require('./functions/postAccessTokenToDatabase');
+const accessTokenSchema = require('./schemas/accessTokenSchema'); 
 
 const PLAID_CLIENT_ID = process.env.PLAID_CLIENT_ID;
 const PLAID_SECRET = process.env.PLAID_SECRET;

--- a/back-end/constants/FAQData.js
+++ b/back-end/constants/FAQData.js
@@ -1,0 +1,21 @@
+/**
+ * Default placeholder FAQ Data. This will be in the DB in the future.
+ */
+const FAQData = {
+    rows: [
+      {
+        title: "Lorem ipsum dolor sit amet 1?",
+        content: "Lorem ipsum dolor sit amet 1",
+      },
+      {
+        title: "Lorem ipsum dolor sit amet 2?",
+        content: "Lorem ipsum dolor sit amet 2",
+      },
+      {
+        title: "Lorem ipsum dolor sit amet 3?",
+        content: "Lorem ipsum dolor sit amet 3",
+      },
+    ],
+};
+  
+module.exports = FAQData;

--- a/back-end/constants/categories.js
+++ b/back-end/constants/categories.js
@@ -1,0 +1,21 @@
+/**
+ * Default categories for transactions. Custom categories may be moved to the 
+ * database in the future.
+ */
+const categories = [
+    { name: "Bank Fees", icon: "MdAccountBalance" },
+    { name: "Cash Advance", icon: "MdAccountBalance" },
+    { name: "Community", icon: "MdAccountBalance" },
+    { name: "Food and Drink", icon: "MdOutlineLocalCafe" },
+    { name: "Healthcare", icon: "AiOutlineHome" },
+    { name: "Interest", icon: "MdAccountBalance" },
+    { name: "Payment", icon: "MdAccountBalance" },
+    { name: "Recreation", icon: "MdOutlineSportsHandball" },
+    { name: "Service", icon: "MdOutlineCastForEducation" },
+    { name: "Shops", icon: "MdOutlineLocalGroceryStore" },
+    { name: "Tax", icon: "MdAccountBalance" },
+    { name: "Transfer", icon: "MdAccountBalance" },
+    { name: "Travel", icon: "MdEmojiTransportation" },
+];
+
+module.exports = categories;

--- a/back-end/functions/constructAccountsArray.js
+++ b/back-end/functions/constructAccountsArray.js
@@ -1,0 +1,28 @@
+/**
+ * Constructs a cleaned, formatted array containing the banks provided
+ * under a given account along with the available and current balance.
+ * @param {*} banks 
+ * @returns 
+ */
+const constructAccountsArr = (banks) => {
+    const ret = [];
+    banks.forEach(function (bank) {
+      console.log(bank.account_id);
+      console.log(bank.balances);
+      const bankObj = {
+        account_id: bank.account_id,
+        balances: {
+          available: bank.balances.available,
+          current: bank.balances.current,
+          currency: bank.balances.iso_currency_code,
+        },
+        name: bank.name,
+        type: bank.type,
+      };
+      ret.push(bankObj);
+    });
+    console.log(ret);
+    return ret;
+  };
+
+  module.exports = constructAccountsArr;

--- a/back-end/functions/constructTransactionArray.js
+++ b/back-end/functions/constructTransactionArray.js
@@ -1,0 +1,39 @@
+/**
+ * Constructs array containing the transations of the bank accounts
+ * provided.
+ * @param {*} transactions 
+ * @param {*} accounts 
+ * @returns 
+ */
+const constructTransactionArr = (transactions, accounts) => {
+    const ret = [];
+    const accountNameMap = accounts.reduce(
+      (currentMap, { account_id, name }) => ({
+        ...currentMap,
+        [account_id]: name,
+      }),
+      {}
+    );
+    transactions.forEach(function (transaction) {
+      console.log(transaction.account_id);
+      console.log(transaction.amount);
+      const tranObj = {
+        id: transaction.transaction_id,
+        account_id: transaction.account_id,
+        account_name: accountNameMap[transaction.account_id],
+        transaction_id: transaction.transaction_id,
+        amount: transaction.amount,
+        merchant: transaction.merchant_name,
+        date: transaction.date,
+        currency: transaction.iso_currency_code,
+        category: transaction.category,
+        location: transaction.location,
+        transaction_code: transaction.transaction_code,
+      };
+      ret.push(tranObj);
+    });
+    console.log(ret);
+    return ret;
+  };
+
+  module.exports = constructTransactionArr;

--- a/back-end/functions/formatError.js
+++ b/back-end/functions/formatError.js
@@ -1,0 +1,7 @@
+const formatError = (error) => {
+    return {
+      error: { ...error.data, status_code: error.status },
+    };
+};
+
+module.exports = formatError;

--- a/back-end/functions/postAccessTokenToDatabase.js
+++ b/back-end/functions/postAccessTokenToDatabase.js
@@ -1,12 +1,10 @@
+const accessTokenSchema = require('../schemas/accessTokenSchema');
+
 // Function to post access_token to database  
 // Mongoose quickstart: https://mongoosejs.com/docs/index.html
 // TODO: finalize the structure of storing access_token. 
 const postAccessTokenToDatabase = async ( access_token_object ) => {
-  // Step 1: create schema 
-  const accessTokenSchema = new mongoose.Schema({
-    access_token: String, 
-    item_id: String
-  });
+  // step 1: construct schema (imported from '../schemas/accessTokenSchema')
 
   // Step 2: compile schema to model 
   const AccessToken = mongoose.model('AccessToken', accessTokenSchema);

--- a/back-end/functions/postAccessTokenToDatabase.js
+++ b/back-end/functions/postAccessTokenToDatabase.js
@@ -1,0 +1,21 @@
+// Function to post access_token to database  
+// Mongoose quickstart: https://mongoosejs.com/docs/index.html
+// TODO: finalize the structure of storing access_token. 
+const postAccessTokenToDatabase = async ( access_token_object ) => {
+  // Step 1: create schema 
+  const accessTokenSchema = new mongoose.Schema({
+    access_token: String, 
+    item_id: String
+  });
+
+  // Step 2: compile schema to model 
+  const AccessToken = mongoose.model('AccessToken', accessTokenSchema);
+
+  // Step 3: create a schema instance 
+  const accessTokenInstance = new AccessToken(access_token_object);
+
+  // Step 4: save to database
+  await accessTokenInstance.save();
+};
+
+module.exports = postAccessTokenToDatabase;

--- a/back-end/functions/prettyPrintResponse.js
+++ b/back-end/functions/prettyPrintResponse.js
@@ -1,0 +1,6 @@
+const prettyPrintResponse = (response) => {
+    if (response.data) console.log(response.data);
+    else console.log(JSON.stringify(response));
+};
+
+module.exports = prettyPrintResponse;

--- a/back-end/schemas/accessTokenSchema.js
+++ b/back-end/schemas/accessTokenSchema.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose'),
+Schema = mongoose.Schema;
+
+const accessTokenSchema = new mongoose.Schema({
+    access_token: String, 
+    item_id: String
+});
+
+module.exports = accessTokenSchema;

--- a/back-end/test/test.js
+++ b/back-end/test/test.js
@@ -4,6 +4,8 @@ chai.use(chaiHTTP);
 const expect = chai.expect;
 const path = require("path");
 require("mocha-sinon");
+const constructAccountsArr = require('../functions/constructAccountsArray')
+const constructTransactionArr = require('../functions/constructTransactionArray')
 Object.assign(global, require(path.join(__dirname, "../app.js")));
 
 describe("testing routes", () => {
@@ -191,6 +193,54 @@ describe("testing routes", () => {
         };
         expect(formatError(fakeData)).to.have.property("error");
         expect(formatError(fakeData).error).to.have.property("status_code");
+      });
+    });
+  });
+  describe("testing constructing accounts array function", () => {
+    describe("testing constructAccountsArray function with no banks", () => {
+      it("reads function response and returns empty array", () => {
+        const fakeData = [];
+        expect(constructAccountsArr(fakeData)).to.deep.equal([]);
+      });
+    });
+  });
+  describe("testing constructing accounts array function", () => {
+    describe("testing constructAccountsArray function with bank info", () => {
+        it("reads function response and returns constructed array", () => {
+        const fakeData = [
+            {
+              account_id: 'reAXq01pJmFqvNK3yrR4SPYe7wDQg9FBw595w',
+              balances: {
+                available: 3.50,
+                current: 3.50,
+                iso_currency_code: 'USD',
+                limit: null,
+                unofficial_currency_code: null
+              },
+              mask: '8638',
+              name: 'CHASE COLLEGE',
+              official_name: null,
+              subtype: 'checking',
+              type: 'depository'
+            }
+          ];
+
+        const ret = [
+            {
+              account_id: 'reAXq01pJmFqvNK3yrR4SPYe7wDQg9FBw595w',
+              balances: { available: 3.50, current: 3.50, currency: 'USD' },
+              name: 'CHASE COLLEGE',
+              type: 'depository'
+            }
+          ];
+        expect(constructAccountsArr(fakeData)).to.deep.equal(ret);
+        });
+    });
+  });
+  describe("testing constructing transactions array function", () => {
+    describe("testing constructAccountsArray function with no banks", () => {
+      it("reads function response and returns empty array", () => {
+        expect(constructTransactionArr([], [])).to.deep.equal([]);
       });
     });
   });


### PR DESCRIPTION
Related to issue #92.

Making this PR because `back-end/app.js` is approaching 400 lines of code and getting a bit messy, especially once MongoDB code gets added in. 

This change refactors constants (many of which should be migrated to MongoDB after this sprint) into `back-end/constants` directory and functions into `back-end/functions` directory. MongoDB schemas are in `back-end/schemas`.

This change also improves code coverage, since now the individual functions can be tested.

Unit tests ran and passed 18/18 by running `npx nyc mocha test/test.js`.