### PR TITLE
Save access tokens to database under user account

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -274,9 +274,9 @@ app.get("/api/get_transactions", async (request, response, next) => {
         offset: 0,
       },
     };
-    console.log(options);
+    // console.log(options);
     const result = await plaidClient.transactionsGet(options);
-    console.log(JSON.stringify(result.data));
+    // console.log(JSON.stringify(result.data));
     const { accounts, transactions } = result.data;
     return response.json(constructTransactionArr(transactions, accounts));
   } catch (error) {

--- a/back-end/functions/constructAccountsArray.js
+++ b/back-end/functions/constructAccountsArray.js
@@ -7,8 +7,8 @@
 const constructAccountsArr = (banks) => {
     const ret = [];
     banks.forEach(function (bank) {
-      console.log(bank.account_id);
-      console.log(bank.balances);
+      // console.log(bank.account_id);
+      // console.log(bank.balances);
       const bankObj = {
         account_id: bank.account_id,
         balances: {
@@ -21,7 +21,7 @@ const constructAccountsArr = (banks) => {
       };
       ret.push(bankObj);
     });
-    console.log(ret);
+    // console.log(ret);
     return ret;
   };
 

--- a/back-end/functions/constructTransactionArray.js
+++ b/back-end/functions/constructTransactionArray.js
@@ -15,8 +15,8 @@ const constructTransactionArr = (transactions, accounts) => {
       {}
     );
     transactions.forEach(function (transaction) {
-      console.log(transaction.account_id);
-      console.log(transaction.amount);
+      // console.log(transaction.account_id);
+      // console.log(transaction.amount);
       const tranObj = {
         id: transaction.transaction_id,
         account_id: transaction.account_id,
@@ -32,7 +32,7 @@ const constructTransactionArr = (transactions, accounts) => {
       };
       ret.push(tranObj);
     });
-    console.log(ret);
+    // console.log(ret);
     return ret;
   };
 

--- a/back-end/functions/postAccessTokenToDatabase.js
+++ b/back-end/functions/postAccessTokenToDatabase.js
@@ -16,7 +16,7 @@ const postAccessTokenToDatabase = async ( access_token_object, userId ) => {
       }
     })
 
-  accessTokenInstance.save(function(err) {
+  await accessTokenInstance.save(function(err) {
     if(err) {
       console.log(err);
     } else {

--- a/back-end/functions/postAccessTokenToDatabase.js
+++ b/back-end/functions/postAccessTokenToDatabase.js
@@ -12,9 +12,17 @@ const postAccessTokenToDatabase = async ( access_token_object, userId ) => {
       if(err) {
         console.log(err);
       } else {
-        console.log("Successfully saved new access token to db.");
+        console.log("Successfully pushed new access token to user in db.");
       }
     })
+
+  accessTokenInstance.save(function(err) {
+    if(err) {
+      console.log(err);
+    } else {
+      console.log("Successfully saved new access token to db.");
+    }
+  });
 };
 
 module.exports = postAccessTokenToDatabase;

--- a/back-end/functions/postAccessTokenToDatabase.js
+++ b/back-end/functions/postAccessTokenToDatabase.js
@@ -1,18 +1,12 @@
-const accessTokenSchema = require('../schemas/accessTokenSchema');
+const AccessTokenModel = require('../model/accessToken');
 
 // Function to post access_token to database  
 // Mongoose quickstart: https://mongoosejs.com/docs/index.html
 // TODO: finalize the structure of storing access_token. 
 const postAccessTokenToDatabase = async ( access_token_object ) => {
-  // step 1: construct schema (imported from '../schemas/accessTokenSchema')
-
-  // Step 2: compile schema to model 
-  const AccessToken = mongoose.model('AccessToken', accessTokenSchema);
-
-  // Step 3: create a schema instance 
+  // create a schema instance 
   const accessTokenInstance = new AccessToken(access_token_object);
-
-  // Step 4: save to database
+  // save to database
   await accessTokenInstance.save();
 };
 

--- a/back-end/functions/postAccessTokenToDatabase.js
+++ b/back-end/functions/postAccessTokenToDatabase.js
@@ -1,13 +1,20 @@
 const AccessTokenModel = require('../model/accessToken');
+const UserModel = require("../model/user");
 
 // Function to post access_token to database  
 // Mongoose quickstart: https://mongoosejs.com/docs/index.html
-// TODO: finalize the structure of storing access_token. 
-const postAccessTokenToDatabase = async ( access_token_object ) => {
+const postAccessTokenToDatabase = async ( access_token_object, userId ) => {
   // create a schema instance 
-  const accessTokenInstance = new AccessToken(access_token_object);
+  const accessTokenInstance = new AccessTokenModel(access_token_object);
   // save to database
-  await accessTokenInstance.save();
+  UserModel.updateOne({ _id: userId },
+    { $push: {access_token: accessTokenInstance} }, function(err) {
+      if(err) {
+        console.log(err);
+      } else {
+        console.log("Successfully saved new access token to db.");
+      }
+    })
 };
 
 module.exports = postAccessTokenToDatabase;

--- a/back-end/model/accessToken.js
+++ b/back-end/model/accessToken.js
@@ -1,4 +1,4 @@
 const mongoose = require("mongoose");
 const accessTokenSchema = require('../schema/accessToken')
 
-module.exports = mongoose.model('accessTokenModel', accessTokenSchema);
+module.exports = mongoose.model('accessToken', accessTokenSchema);

--- a/back-end/model/accessToken.js
+++ b/back-end/model/accessToken.js
@@ -1,8 +1,4 @@
 const mongoose = require("mongoose");
+const accessTokenSchema = require('../schema/accessToken')
 
-const accessTokenSchema = new mongoose.Schema({
-    access_token: String, 
-    item_id: String
-});
-
-module.exports = mongoose.model('AccessToken', accessTokenSchema);
+module.exports = mongoose.model('accessTokenModel', accessTokenSchema);

--- a/back-end/model/accessToken.js
+++ b/back-end/model/accessToken.js
@@ -1,0 +1,8 @@
+const mongoose = require("mongoose");
+
+const accessTokenSchema = new mongoose.Schema({
+    access_token: String, 
+    item_id: String
+});
+
+module.exports = mongoose.model('AccessToken', accessTokenSchema);

--- a/back-end/model/user.js
+++ b/back-end/model/user.js
@@ -1,10 +1,11 @@
 const mongoose = require("mongoose");
+const AccessTokenSchema = require('../schema/accessToken');
 
 const userSchema = new mongoose.Schema({
   email: { type: String, unique: true },
   password: { type: String },
   jwt_token: { type: String },
-  access_token: { type: [String] }
+  access_token: { type: [AccessTokenSchema] }
 }, { strict: false });
 
 module.exports = mongoose.model("user", userSchema);

--- a/back-end/schema/README.md
+++ b/back-end/schema/README.md
@@ -1,0 +1,7 @@
+## What this directory is for
+
+This directory should contain schemas that need to eventually be exported. If there is no need to separate the compiled model from the schema itsself, please do not modularize (i.e. see `model/user.js` as an example of just having the model.)
+
+The reason that `accessToken.js` is under this directory is that it needs to be used in the `AccessToken` model as well as in the `User` model schema to construct an array of `AccessToken`.
+
+To summarize: schemas under schemas directory should be exported as schema itself, not as the compiled version (aka the model). Please only separate schemas from models if you must. Otherwise, have them as just a compiled model.

--- a/back-end/schema/accessToken.js
+++ b/back-end/schema/accessToken.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose'),
+Schema = mongoose.Schema;
+
+const accessTokenSchema = new mongoose.Schema({
+    access_token: String, 
+    item_id: String
+});
+
+module.exports = accessTokenSchema;

--- a/back-end/schemas/accessTokenSchema.js
+++ b/back-end/schemas/accessTokenSchema.js
@@ -1,9 +1,0 @@
-const mongoose = require('mongoose'),
-Schema = mongoose.Schema;
-
-const accessTokenSchema = new mongoose.Schema({
-    access_token: String, 
-    item_id: String
-});
-
-module.exports = accessTokenSchema;

--- a/front-end/src/components/Accounts/AccountsPage.js
+++ b/front-end/src/components/Accounts/AccountsPage.js
@@ -15,6 +15,7 @@ const PlaidLink = (props) => {
     axios
       .post("/api/set_access_token", {
         public_token: public_token,
+        _id: JSON.parse(sessionStorage.getItem('user'))._id,
       })
       .then((resp) => {
         console.log(resp.data);


### PR DESCRIPTION
This PR combines #91 and #98. 
- [x] refactor UserSchema to contain an array of AccessTokenSchema instead of String
- [x] pass in `_id` to request body for `/api/set_access_token` route so that backend can save the new `access_token` to the appropriate user in the db
- [x] create AccessToken model in the `model` directory (saving individual access tokens to db is unnecessary, but I did it anyways in case we may need it in the future)

- [x] push new `access_token` to appropriate user in db and save `access_token` to db
- [x] modify `app.js` to save new users into the db

Note that I left the `schema` directory because I needed to separate the `access_token` schema from the model so that I could import it into the `user` model (see first note about UserSchema).

To test with a new user:
1. press `cmd+shift+j` or whatever launches the developer tools in your browser.
2. go to "Application" and clear the local storage.
3. log in if you haven't already
4. click Add New Bank Account and authorize a bank
5. check the log in your terminal to look for something along the lines of "saved to database successfully" message
6. check database under [`user` collection](https://cloud.mongodb.com/v2/618d76f60797a3540b4dbb9d#metrics/replicaSet/618d785c0b19596db8bb8053/explorer/database/users/find) to verify that `access_token` has been saved