### PR TITLE
Unit tests for login and register 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Run the program:
 
    Run the program
 
-   `npm run start`
+   `npm start`
 
 5. Application should pop up [here](http://localhost:3000/)!
 
@@ -80,7 +80,7 @@ Test the program:
 
    Run for unit test and code coverage:
 
-   `npx nyc mocha test/test.js --exit`
+   `npm test`
 
 ## References
 

--- a/back-end/README.md
+++ b/back-end/README.md
@@ -1,0 +1,1 @@
+### To run the backend or test the code, go to [root directory README](../README.md)

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "nodemon server.js --ignore client",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npx nyc mocha test/test.js --exit"
   },
   "author": "",
   "license": "ISC",

--- a/back-end/readme.txt
+++ b/back-end/readme.txt
@@ -1,3 +1,0 @@
-The back-end of your project will live in this directory.
-
-You will most likely initiate the back-end Node.js/Express.js server by running the "npm init" command from within this directory.

--- a/back-end/test/test.js
+++ b/back-end/test/test.js
@@ -253,7 +253,6 @@ describe("testing routes", () => {
     });
   });
   describe("testing post route on /api/register", () => {
-    // test on empty strings in req body 
     it("fails to register user due to empty input, returns a 400 status", function (cb) {
       chai
         .request(app)
@@ -267,7 +266,6 @@ describe("testing routes", () => {
           cb();
         });
     });
-    // test on invalid password 
     it("fails to register user due to invalid password length, returns a 400 status", function (cb) {
       chai
         .request(app)
@@ -281,7 +279,6 @@ describe("testing routes", () => {
           cb();
         });
     });
-    // test on successful registration  
     it("successfully register user and returns a 201 status", function (cb) {
       chai
         .request(app)
@@ -295,7 +292,6 @@ describe("testing routes", () => {
           cb();
         });
     });
-    // test on the scenario user already registered   
     it("fails to register user due to user already exists, returns a 409 status", function (cb) {
       chai
         .request(app)
@@ -315,7 +311,6 @@ describe("testing routes", () => {
     })
   });
   describe("testing post route on /api/login", () => {
-    // test on empty strings in req body 
     it("fails to log in user due to empty input, returns a 400 status", function (cb) {
       chai
         .request(app)
@@ -329,7 +324,6 @@ describe("testing routes", () => {
           cb();
         });
     });
-    // test on user nonexistence
     it("fails to log in user due to user nonexistence, returns a 404 status", function (cb) {
       chai
         .request(app)
@@ -343,7 +337,6 @@ describe("testing routes", () => {
           cb();
         });
     });
-    // test on invalid credentials 
     it("fails to log in user due to invalid credentials, returns a 401 status", function (cb) {
       chai
         .request(app)
@@ -357,7 +350,6 @@ describe("testing routes", () => {
           cb();
         });
     });
-    // test on invalid credentials 
     it("successfully log in user, returns a 200 status", function (cb) {
       chai
         .request(app)

--- a/back-end/test/test.js
+++ b/back-end/test/test.js
@@ -6,6 +6,7 @@ const path = require("path");
 require("mocha-sinon");
 const constructAccountsArr = require("../functions/constructAccountsArray");
 const constructTransactionArr = require("../functions/constructTransactionArray");
+const UserModel = require("../model/user");
 Object.assign(global, require(path.join(__dirname, "../app.js")));
 
 describe("testing routes", () => {
@@ -249,6 +250,126 @@ describe("testing routes", () => {
           "account_id"
         );
       });
+    });
+  });
+  describe("testing post route on /api/register", () => {
+    // test on empty strings in req body 
+    it("fails to register user due to empty input, returns a 400 status", function (cb) {
+      chai
+        .request(app)
+        .post("/api/register")
+        .send({
+          email: '',
+          password: ''
+        })
+        .end(function (err, res) {
+          expect(res).to.have.status(400);
+          cb();
+        });
+    });
+    // test on invalid password 
+    it("fails to register user due to invalid password length, returns a 400 status", function (cb) {
+      chai
+        .request(app)
+        .post("/api/register")
+        .send({
+          email: 'jennifer-unit-test@gmail',
+          password: 'hh'
+        })
+        .end(function (err, res) {
+          expect(res).to.have.status(400);
+          cb();
+        });
+    });
+    // test on successful registration  
+    it("successfully register user and returns a 201 status", function (cb) {
+      chai
+        .request(app)
+        .post("/api/register")
+        .send({
+          email: 'jennifer-unit-test@gmail',
+          password: 'jennifer'
+        })
+        .end(function (err, res) {
+          expect(res).to.have.status(201);
+          cb();
+        });
+    });
+    // test on the scenario user already registered   
+    it("fails to register user due to user already exists, returns a 409 status", function (cb) {
+      chai
+        .request(app)
+        .post("/api/register")
+        .send({
+          email: 'jennifer-unit-test@gmail',
+          password: 'jennifer'
+        })
+        .end(function (err, res) {
+          expect(res).to.have.status(409);
+          cb();
+        });
+    });
+    // remove mock user from the database 
+    after(async () => {
+      await UserModel.deleteOne({ email: 'jennifer-unit-test@gmail' });
+    })
+  });
+  describe("testing post route on /api/login", () => {
+    // test on empty strings in req body 
+    it("fails to log in user due to empty input, returns a 400 status", function (cb) {
+      chai
+        .request(app)
+        .post("/api/login")
+        .send({
+          email: '',
+          password: ''
+        })
+        .end(function (err, res) {
+          expect(res).to.have.status(400);
+          cb();
+        });
+    });
+    // test on user nonexistence
+    it("fails to log in user due to user nonexistence, returns a 404 status", function (cb) {
+      chai
+        .request(app)
+        .post("/api/login")
+        .send({
+          email: 'jennifer-unit-test@gmail.com',
+          password: 'jennifer'
+        })
+        .end(function (err, res) {
+          expect(res).to.have.status(404);
+          cb();
+        });
+    });
+    // test on invalid credentials 
+    it("fails to log in user due to invalid credentials, returns a 401 status", function (cb) {
+      chai
+        .request(app)
+        .post("/api/login")
+        .send({
+          email: 'alan@gmail.com',
+          password: 'jennifer'
+        })
+        .end(function (err, res) {
+          expect(res).to.have.status(401);
+          cb();
+        });
+    });
+    // test on invalid credentials 
+    it("successfully log in user, returns a 200 status", function (cb) {
+      chai
+        .request(app)
+        .post("/api/login")
+        .send({
+          email: 'alan@gmail.com',
+          password: 'test123'
+        })
+        .end(function (err, res) {
+          expect(res).to.have.status(200);
+          cb();
+        });
     });
   });
 });


### PR DESCRIPTION
**Done in this PR:** 
1. Added unit tests for login and register 
testing post route on /api/register
      ✔ fails to register user due to empty input, returns a 400 status
      ✔ fails to register user due to invalid password length, returns a 400 status
      ✔ successfully register user and returns a 201 status (551ms)
      ✔ fails to register user due to user already exists, returns a 409 status (47ms)
testing post route on /api/login
      ✔ fails to log in user due to empty input, returns a 400 status
      ✔ fails to log in user due to user nonexistence, returns a 404 status
      ✔ fails to log in user due to invalid credentials, returns a 401 status (38ms)
      ✔ successfully log in user, returns a 200 status (86ms)

2. Updated 'npm test' command for backend to run the tests and see code coverage. Enabled circleci to actually run the tests" 

Closes #97