### PR TITLE
Fixed null error on FAQ page (deployment site) due to routing issues

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -390,7 +390,7 @@ app.post("/api/setTransactionNotes", async (request, response) => {
   }
 });
 
-app.get("/faq", async (req, resp) => {
+app.get("/api/faq", async (req, resp) => {
   resp.json(FAQData);
 });
 
@@ -401,7 +401,7 @@ Contact Info get + post routes:
   - stores temp in array until db implementation
 */
 let contactInfo = {};
-app.get("/contactInfo", async (req, resp) => {
+app.get("/api/contactInfo", async (req, resp) => {
   try {
     const confirmationMessage = contactInfo;
     contactInfo = {};
@@ -412,7 +412,7 @@ app.get("/contactInfo", async (req, resp) => {
   }
 });
 
-app.post("/contactInfo", async (req, resp) => {
+app.post("/api/contactInfo", async (req, resp) => {
   try {
     contactInfo.name = req.body.name;
     contactInfo.email = req.body.email;

--- a/front-end/src/components/ContactForm.js
+++ b/front-end/src/components/ContactForm.js
@@ -15,7 +15,7 @@ const ContactForm = () => {
       email: e.target.email.value,
       message: e.target.message.value,
     };
-    axios.post("/contactInfo", contactInfo);
+    axios.post("/api/contactInfo", contactInfo);
 
     history.push("/contactConfirm");
   };

--- a/front-end/src/components/ContactFormConfirm.js
+++ b/front-end/src/components/ContactFormConfirm.js
@@ -4,7 +4,7 @@ import axios from "axios";
 import { useAsync } from "../utils";
 
 const ContactFormConfirm = () => {
-  const { data } = useAsync(async () => axios.get("/contactInfo"), []);
+  const { data } = useAsync(async () => axios.get("/api/contactInfo"), []);
   const name = data?.data?.name ?? "";
   const email = data?.data?.email ?? "";
   console.log("body:");

--- a/front-end/src/components/FAQ/FAQ.js
+++ b/front-end/src/components/FAQ/FAQ.js
@@ -4,7 +4,7 @@ import axios from "axios";
 import { useAsync } from "../../utils";
 
 const FAQ = () => {
-  const { data } = useAsync(async () => axios.get("/faq"), []);
+  const { data } = useAsync(async () => axios.get("/api/faq"), []);
 
   const styles = {
     bgColor: "#dcf7fa",


### PR DESCRIPTION
**Issues:** 
Previously on deployment site, FAQ page and Contact Us page doesn't function correctly; specifically query to `/faq` endpoint returned HTML file rather than JSON, and same for Contact Us page. 

**Problem Diagnostics:** 
The reason for the incorrect format of return is due to routing issues. "/faq" will look up pages in the frontend rather than the backend routes, thus returning an HTML file. 

**Solution:** 
Change all routes in the backend to `/api/<some_route>`
