### PR TITLE
Fix memory issue on deployment server when running `npm run build`

### DIFF
--- a/front-end/package.json
+++ b/front-end/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts --max_old_space_size=8192 build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
**Issues:** 
When running npm run build on the deployment server, we have encountered two problems: 
1. `npm run build` exits too early. 
2. `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`

**Solutions:** 
These two problems are both due to the limited memory size we have on the deployment server. I have done the following two things to resolve memory issues. 
1. added swap space to temporarily hold data 
2. updated build script to temporarily increase memory for Nodejs **(Done in this PR)** 

References: 
1. [`npm run build` exits too early](https://create-react-app.dev/docs/troubleshooting/#npm-run-build-exits-too-early)
2. [heap out of memory](https://stackoverflow.com/questions/53230823/fatal-error-ineffective-mark-compacts-near-heap-limit-allocation-failed-javas)