### PR TITLE
Config circleci for continuous deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,13 @@ jobs:
           cd front-end
           npm install # install all dependencies listed in package.json
           CI=false npm run build # have react build the stand-alone front-end code
+  deploy-prod:
+    docker:
+      - image: circleci/node:16.13.0
+    steps:
+      - checkout
+      - run: echo "this is the deployment job"
+      - run: ssh -oStrictHostKeyChecking=no -v $DROPLET_USER@$DROPLET_IP “./deploy_project.sh”
 
 # Orchestrate our job run sequence
 workflows:
@@ -47,3 +54,13 @@ workflows:
   build-front-end:
     jobs:
       - build-react-js
+  deploy:
+    jobs:
+      - deploy-prod:
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - build-and-test-express-js
+            - build-react-js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,8 @@ workflows:
       - build-react-js
   deploy:
     jobs:
+      - build-and-test-express-js
+      - build-react-js
       - deploy-prod:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - checkout
       - run: echo "this is the deployment job"
-      - run: ssh -oStrictHostKeyChecking=no -v $DROPLET_USER@$DROPLET_IP “./deploy_project.sh”
+      - run: ssh -o StrictHostKeyChecking=no -v $DROPLET_USER@$DROPLET_IP “./deploy_project.sh”
 
 # Orchestrate our job run sequence
 workflows:


### PR DESCRIPTION
Modified the CircleCI config file to automatically deploy to the deployment server when changes are made to the master branch. 

`deploy` in `workflow` will first run the frontend and backend job. Once these jobs succeed, it will continue to `deploy-prod` job. Only when master branch has been updated, `deploy-prod` will run. 

`./deploy.sh` is a script on the deployment server. Once CircleCI ssh into the server, it will run this script, which will handle all git pull, build and other steps necessary for deployment. 

Reference: 
[Config CircleCI](https://circleci.com/docs/2.0/configuration-reference/#)
