### PR TITLE
delete categories

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -29,6 +29,7 @@ const setTransactionNotesInDatabase = require("./functions/setTransactionNotesIn
 const setTransactionCategoryInDatabase = require("./functions/setTransactionCategoryInDatabase");
 const postCategory = require("./functions/postCategory");
 const editCategory = require("./functions/editCategory");
+const deleteCategory = require("./functions/deleteCategory");
 
 const PLAID_CLIENT_ID = process.env.PLAID_CLIENT_ID;
 const PLAID_SECRET = process.env.PLAID_SECRET;
@@ -183,11 +184,8 @@ app.post("/api/register", async (req, res) => {
 // function to get categories from Plaid
 app.get("/api/categories", async (req, resp) => {
   try {
-    // resp.json({});
     const userId = req.query._id;
     const categories = await getCategories(userId);
-    // resp.json({});
-
     categories.categories.sort((a, b) => a.name.localeCompare(b.name));
     resp.json(categories.categories);
   } catch (error) {
@@ -217,6 +215,18 @@ app.post("/api/changeCategories", async (req, resp) => {
       icon: req.body.icon,
       oldName: req.body.oldName,
       oldIcon: req.body.oldIcon,
+    },
+    userId
+  );
+  resp.json(result);
+});
+
+app.post("/api/deleteCategories", async (req, resp) => {
+  const userId = req.body.id;
+  const result = await deleteCategory(
+    {
+      name: req.body.name,
+      icon: req.body.icon,
     },
     userId
   );

--- a/back-end/functions/deleteCategory.js
+++ b/back-end/functions/deleteCategory.js
@@ -2,7 +2,7 @@ const AccessTokenModel = require("../model/accessToken");
 const UserModel = require("../model/user");
 
 // Mongoose quickstart: https://mongoosejs.com/docs/index.html
-const editCategory = async (category, userId) => {
+const deleteCategory = async (category, userId) => {
   const found = await UserModel.exists({
     _id: userId,
     "categories.name": category.name,
@@ -26,4 +26,4 @@ const editCategory = async (category, userId) => {
   return found;
 };
 
-module.exports = editCategory;
+module.exports = deleteCategory;

--- a/back-end/functions/deleteCategory.js
+++ b/back-end/functions/deleteCategory.js
@@ -1,0 +1,29 @@
+const AccessTokenModel = require("../model/accessToken");
+const UserModel = require("../model/user");
+
+// Mongoose quickstart: https://mongoosejs.com/docs/index.html
+const editCategory = async (category, userId) => {
+  const found = await UserModel.exists({
+    _id: userId,
+    "categories.name": category.name,
+    "categories.icon": category.icon,
+  });
+  UserModel.updateOne(
+    {
+      _id: userId,
+      "categories.name": category.name,
+      "categories.icon": category.icon,
+    },
+    { $pull: { categories: { name: category.name } } },
+    function (err) {
+      if (err) {
+        console.log(err);
+      } else {
+        console.log("Successfully deleted category name", category.name);
+      }
+    }
+  );
+  return found;
+};
+
+module.exports = editCategory;

--- a/back-end/test/test.js
+++ b/back-end/test/test.js
@@ -333,7 +333,52 @@ describe("testing routes", () => {
           cb();
         });
     });
+    it("returns successful check for found category", function (cb) {
+      chai
+        .request(app)
+        .post("/api/deleteCategories")
+        .send({
+          _id: 0,
+          name: "tName",
+          icon: "tIcon",
+        })
+        .end(function (err, res) {
+          expect(res);
+          cb();
+        });
+    });
   });
+  describe("testing post route /api/deleteCategories", () => {
+    it("returns a 200 status with valid category info", function (cb) {
+      chai
+        .request(app)
+        .post("/api/deleteCategories")
+        .send({
+          _id: 0,
+          name: "tName",
+          icon: "tIcon",
+        })
+        .end(function (err, res) {
+          expect(res).to.have.status(200);
+          cb();
+        });
+    });
+    it("returns no duplicate category found", function (cb) {
+      chai
+        .request(app)
+        .post("/api/deleteCategories")
+        .send({
+          _id: 0,
+          name: "tName",
+          icon: "tIcon",
+        })
+        .end(function (err, res) {
+          expect(res);
+          cb();
+        });
+    });
+  });
+
   describe("testing post route /api/create_link_token", () => {
     it("returns a 200 status", function (cb) {
       chai

--- a/back-end/test/test.js
+++ b/back-end/test/test.js
@@ -309,7 +309,7 @@ describe("testing routes", () => {
       chai
         .request(app)
         .post("/api/categories")
-        .send({ category: "testing", _id: 0 })
+        .send({ category: "testing", id: undefined })
         .end(function (err, res) {
           expect(res).to.have.status(200);
           cb();
@@ -322,7 +322,7 @@ describe("testing routes", () => {
         .request(app)
         .post("/api/changeCategories")
         .send({
-          _id: 0,
+          id: undefined,
           name: "tName",
           icon: "tIcon",
           oldName: "oName",
@@ -338,7 +338,7 @@ describe("testing routes", () => {
         .request(app)
         .post("/api/deleteCategories")
         .send({
-          _id: 0,
+          id: undefined,
           name: "tName",
           icon: "tIcon",
         })
@@ -354,7 +354,7 @@ describe("testing routes", () => {
         .request(app)
         .post("/api/deleteCategories")
         .send({
-          _id: 0,
+          id: undefined,
           name: "tName",
           icon: "tIcon",
         })
@@ -368,7 +368,7 @@ describe("testing routes", () => {
         .request(app)
         .post("/api/deleteCategories")
         .send({
-          _id: 0,
+          id: undefined,
           name: "tName",
           icon: "tIcon",
         })

--- a/front-end/src/api/index.js
+++ b/front-end/src/api/index.js
@@ -63,6 +63,22 @@ async function editCategory(name, icon, oldName, oldIcon) {
   }
 }
 
+async function deleteCategory(name, icon) {
+  try {
+    const id = sessionStorage.getItem("user")
+      ? JSON.parse(sessionStorage.getItem("user"))._id
+      : null;
+    const result = await axios.post("/api/deleteCategories", {
+      id,
+      name,
+      icon,
+    });
+    return result.data;
+  } catch (err) {
+    console.error(err);
+  }
+}
+
 async function setTransactionCategory(id, newCategory) {
   try {
     await axios.post("/api/setTransactionCategory", {
@@ -152,6 +168,7 @@ async function getAccountInfo() {
 const api = {
   postNewCategory,
   editCategory,
+  deleteCategory,
   getCategoryList,
   getAllTransactions,
   getRecentTransactions,

--- a/front-end/src/pages/Categories.js
+++ b/front-end/src/pages/Categories.js
@@ -37,6 +37,20 @@ const CategoryOverlay = ({ category, closeOverlay }) => {
     return null;
   }
 
+  const defaultCategories = [
+    "Bank Fees",
+    "Community",
+    "Food and Drink",
+    "Healthcare",
+    "Payment",
+    "Recreation",
+    "Service",
+    "Shops",
+    "Tax",
+    "Transfer",
+    "Travel",
+  ];
+
   const Icon = iconNameToComponent[category.icon];
   // const [name, setName] = useState(category?.name);
   return (
@@ -51,16 +65,18 @@ const CategoryOverlay = ({ category, closeOverlay }) => {
         <h2>Category: {category.name}</h2>
         <Icon className="category-icon" />
         <br />
-        <Button
-          type="submit"
-          variant="contained"
-          onClick={handleSubmit}
-          component={Link}
-          to="/homepage"
-        >
-          {" "}
-          Edit{" "}
-        </Button>
+        {!defaultCategories.includes(category.name) ? (
+          <Button
+            type="submit"
+            variant="contained"
+            onClick={handleSubmit}
+            component={Link}
+            to="/homepage"
+          >
+            {" "}
+            Edit{" "}
+          </Button>
+        ) : null}
         <h4>Transactions</h4>
         <div className="overlay-transactions-wrapper">
           <div className={cx("overlay-transactions")}>

--- a/front-end/src/pages/EditCategory.js
+++ b/front-end/src/pages/EditCategory.js
@@ -39,6 +39,8 @@ const EditCategory = (props) => {
   const [name, setName] = React.useState(oldName);
 
   const [exists, setExists] = React.useState(true);
+  const [emptyTransactions, setEmptyTransactions] = React.useState(true);
+
   const history = useHistory();
 
   const onSubmit = React.useCallback(
@@ -65,6 +67,18 @@ const EditCategory = (props) => {
     setName(e.target.value);
   };
 
+  const handleDelete = (e) => {
+    e.preventDefault();
+    console.log("trans", transactions.length);
+    if (transactions.length === 0) {
+      setEmptyTransactions(true);
+      // const result = await api.deleteCategory(oldName, oldIcon);
+    } else {
+      setEmptyTransactions(false);
+    }
+    // history.push("/categories");
+  };
+
   return (
     <div>
       <h1>Edit Category</h1>
@@ -87,6 +101,24 @@ const EditCategory = (props) => {
           Update
         </button>
       </form>
+      <br /> <br />
+      <div className="container">
+        <b>Note: You can only delete empty categories.</b>
+        <br />
+        <hr />
+        {!emptyTransactions ? (
+          <p id="warning">
+            {" "}
+            There are still transactions in this category. Please reassign them
+            first!
+          </p>
+        ) : null}
+        <br />
+        <button className={styles.muiButton} onClick={handleDelete} id="del">
+          Delete
+        </button>
+      </div>
+      <br /> <br />
     </div>
   );
 };

--- a/front-end/src/pages/EditCategory.js
+++ b/front-end/src/pages/EditCategory.js
@@ -67,22 +67,29 @@ const EditCategory = (props) => {
     setName(e.target.value);
   };
 
-  const handleDelete = (e) => {
-    e.preventDefault();
-    console.log("trans", transactions.length);
-    if (transactions.length === 0) {
-      setEmptyTransactions(true);
-      // const result = await api.deleteCategory(oldName, oldIcon);
-    } else {
-      setEmptyTransactions(false);
-    }
-    // history.push("/categories");
-  };
+  const handleDelete = React.useCallback(
+    async (e) => {
+      e.preventDefault();
+      if (transactions === undefined) {
+        setExists(false);
+      } else {
+        setExists(true);
+        if (transactions.length === 0) {
+          setEmptyTransactions(true);
+          const result = await api.deleteCategory(oldName, oldIcon);
+          history.push("/categories");
+        } else {
+          setEmptyTransactions(false);
+        }
+      }
+    },
+    [history, oldName, oldIcon, transactions?.length]
+  );
 
   return (
     <div>
       <h1>Edit Category</h1>
-      {!exists ? <h2> Category does not exist!</h2> : null}
+      {!exists ? <h2 id="warning"> Category does not exist!</h2> : null}
       <form onSubmit={onSubmit} className="container">
         <label htmlFor="name" className={styles.marginBottom}>
           <b>Category Name:</b>
@@ -104,15 +111,17 @@ const EditCategory = (props) => {
       <br /> <br />
       <div className="container">
         <b>Note: You can only delete empty categories.</b>
-        <br />
+
         <hr />
         {!emptyTransactions ? (
           <p id="warning">
-            {" "}
-            There are still transactions in this category. Please reassign them
-            first!
+            <b>
+              There are still transactions in this category. Please reassign
+              them first!
+            </b>
           </p>
         ) : null}
+
         <br />
         <button className={styles.muiButton} onClick={handleDelete} id="del">
           Delete

--- a/front-end/src/pages/css/IconGrid.css
+++ b/front-end/src/pages/css/IconGrid.css
@@ -8,3 +8,11 @@
 .selected-icon {
   border: solid black 4px;
 }
+
+#del {
+  background-color: red;
+}
+
+#warning {
+  color: red;
+}


### PR DESCRIPTION
- add ability to delete categories for user-created categories
- added unit test
- requires category to be empty/no transactions (I added a check for this)
- features 🍿:

deleting a category w/ no transactions (valid)
<img width="250" alt="Screen Shot 2021-12-03 at 5 35 13 PM" src="https://user-images.githubusercontent.com/34128141/144683792-dcc1a0a6-5748-4d05-ad3c-e65f4c9c69bc.png">

deleting a category w/ transactions (invalid)
<img width="250" alt="Screen Shot 2021-12-03 at 5 34 35 PM" src="https://user-images.githubusercontent.com/34128141/144683845-0ae2fc69-f157-4a53-8e44-e009d9e66fdd.png">

not accessing category through editCategory button
<img width="250" alt="Screen Shot 2021-12-03 at 5 36 10 PM" src="https://user-images.githubusercontent.com/34128141/144683880-10d44573-430c-445a-84f8-982b154f330c.png">

before:
<img width="250" alt="Screen Shot 2021-12-03 at 5 35 35 PM" src="https://user-images.githubusercontent.com/34128141/144683891-18c5c071-abe2-46ef-a0f9-e19014bb4f4c.png">

after:
<img width="250" alt="Screen Shot 2021-12-03 at 5 35 42 PM" src="https://user-images.githubusercontent.com/34128141/144683886-065df749-3a39-4f92-8e4c-44c96a261408.png">

default cats (can't change):
<img width="250" alt="Screen Shot 2021-12-04 at 11 15 39 PM" src="https://user-images.githubusercontent.com/34128141/144733314-c778a508-6976-4569-a399-9a5da3ccf809.png">


user-created cats (can change)
<img width="250" alt="Screen Shot 2021-12-04 at 11 15 44 PM" src="https://user-images.githubusercontent.com/34128141/144733311-1128f9d4-d591-4a46-91eb-3c6072f990bb.png">

