### PR TITLE
improve cat documentation

### DIFF
--- a/back-end/constants/FAQData.js
+++ b/back-end/constants/FAQData.js
@@ -15,6 +15,11 @@ const FAQData = {
       content:
         "Click on any transaction. Hover over the icons to see which category you would like to move it do. Click!",
     },
+    {
+      title: "Why can't I edit default categories?",
+      content:
+        "Each transaction through Plaid is categorized into default categories. Changing or deleting those categories prevents future transactions from then showing up in the categories list.",
+    },
   ],
 };
 

--- a/front-end/src/pages/Categories.js
+++ b/front-end/src/pages/Categories.js
@@ -76,7 +76,9 @@ const CategoryOverlay = ({ category, closeOverlay }) => {
             {" "}
             Edit{" "}
           </Button>
-        ) : null}
+        ) : (
+          <h4> Default categories cannot be editted. </h4>
+        )}
         <h4>Transactions</h4>
         <div className="overlay-transactions-wrapper">
           <div className={cx("overlay-transactions")}>

--- a/front-end/src/pages/Categories.js
+++ b/front-end/src/pages/Categories.js
@@ -77,7 +77,7 @@ const CategoryOverlay = ({ category, closeOverlay }) => {
             Edit{" "}
           </Button>
         ) : (
-          <h4> Default categories cannot be editted. </h4>
+          <h4> Default categories cannot be edited. </h4>
         )}
         <h4>Transactions</h4>
         <div className="overlay-transactions-wrapper">


### PR DESCRIPTION
- gives user warning when they cannot edit a category bc it's a default one
<img width="200" alt="Screen Shot 2021-12-05 at 7 06 25 PM" src="https://user-images.githubusercontent.com/34128141/144769653-6c436b60-18ef-4d28-9a27-305acee44b6d.png">

- provides an explanation in the faq as well
<img width="200" alt="Screen Shot 2021-12-05 at 7 05 38 PM" src="https://user-images.githubusercontent.com/34128141/144769661-1d996850-8d0f-4f7e-8f8b-f05a0ec29093.png">

