### PR TITLE
minor CSS fixes - fixed text wrapping with long words

### DIFF
--- a/front-end/src/components/css/ContactForm.css
+++ b/front-end/src/components/css/ContactForm.css
@@ -1,6 +1,6 @@
 .container-contact {
   background-color: #dcf7fa;
-  width: 20%;
+  width: 80%;
   margin: auto;
   border: 2px solid #afecf4;
   border-radius: 5px;
@@ -11,8 +11,9 @@
 
 .container-confirm {
   background-color: #dcf7fa;
-  width: 20%;
+  width: 80%;
   margin: auto;
+  word-wrap: break-word;
   border: 2px solid #afecf4;
   border-radius: 5px;
   padding: 1%;

--- a/front-end/src/components/css/Homepage.css
+++ b/front-end/src/components/css/Homepage.css
@@ -1,6 +1,6 @@
 .container-home {
   background-color: #dcf7fa;
-  width: 80%;
+  width: 90%;
   margin: auto;
   border: 2px solid #afecf4;
   border-radius: 5px;
@@ -11,9 +11,8 @@
 
 .statContainer {
   background-color: #dcf7fa;
-
   overflow: scroll;
-  width: 80%;
+  width: 90%;
   margin: auto;
   border: 2px solid #afecf4;
   border-radius: 5px;


### PR DESCRIPTION
<img width="457" alt="Screen Shot 2021-12-10 at 1 03 27 PM" src="https://user-images.githubusercontent.com/72414544/145620840-f524d09b-faa8-4f05-baca-bc8805cddd6e.png">
![Screen Shot 2021-12-10 at 12 56 14 PM](https://user-images.githubusercontent.com/72414544/145620889-2cf1987a-3168-402e-9b0a-1b8745b6f83a.png)

