### PR TITLE
changes for deleting correct account 

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -329,11 +329,15 @@ app.post("/api/get_bank_accounts", async (req, response, next) => {
 
     const allAccounts = [];
     for (const token of accessTokensArr) {
-      const tempAccount = await plaidClient.accountsGet({
-        access_token: token.access_token,
-      });
-      for (const accountObj of tempAccount.data.accounts) {
-        allAccounts.push(accountObj);
+      try {
+        const tempAccount = await plaidClient.accountsGet({
+          access_token: token.access_token,
+        });
+        for (const accountObj of tempAccount.data.accounts) {
+          allAccounts.push(accountObj);
+        }
+      } catch (error) {
+        continue; // just skip current account
       }
     }
     return response.json(constructAccountsArr(allAccounts));
@@ -479,9 +483,10 @@ app.post("/api/contactInfo", async (req, resp) => {
 app.post("/api/delete_account", async (req, res) => {
   try {
     const bankName = req.body.account_name;
+    const bankId = req.body.account_id;
     const id = req.body._id;
     const accessTokensArr = await getAccessTokens(id); // get all tokens
-    removeAccount(bankName, accessTokensArr, id);
+    removeAccount(bankName, bankId, accessTokensArr, id);
     return res.status(200).json({ removed: bankName, successful: true });
   } catch (error) {
     console.log(error);

--- a/back-end/functions/removeAccount.js
+++ b/back-end/functions/removeAccount.js
@@ -27,7 +27,7 @@ const plaidClient = new PlaidApi(configuration);
  * @param {*} userId
  * @returns true if account was removed, false otherwise
  */
-const removeAccount = async (curAccountName, accessTokensArr, userId) => {
+const removeAccount = async (curAccountName, curAccountId, accessTokensArr, userId) => {
   try {
     for (const token of accessTokensArr) {
       const tempAccount = await plaidClient.accountsGet({
@@ -37,7 +37,9 @@ const removeAccount = async (curAccountName, accessTokensArr, userId) => {
       const accountArr = tempAccount?.data?.accounts ? tempAccount?.data?.accounts : [];
       // check each bank's accounts to see if account to be removed exists
       for (const accountObj of accountArr) {
-        if (accountObj.name === curAccountName) {
+        console.log(accountObj.account_id);
+        console.log(curAccountId);
+        if (accountObj.name === curAccountName && accountObj.account_id === curAccountId) {
           UserModel.updateOne(
             { _id: userId },
             { $pull: { access_token: token } },

--- a/front-end/src/components/AccountDetail/AccountDetail.js
+++ b/front-end/src/components/AccountDetail/AccountDetail.js
@@ -39,10 +39,12 @@ function AccountDetail(props) {
             axios
               .post("/api/delete_account", {
                 account_name: props.bankDetails.name,
+                account_id: props.bankDetails.account_id,
                 _id: JSON.parse(sessionStorage.getItem("user"))._id,
               })
               .then((resp) => {
-                console.log(resp.data);
+                console.log(props.bankDetails);
+                // console.log(props.bankDetails.account_id);
                 alert("Account successfully removed.");
                 window.location.reload();
                 // props.showAccountDetail(false);


### PR DESCRIPTION
This PR makes sure to use a unique identifier to delete bank accounts, rather than name. It also ensures that the `get_bank_accounts` does not break when an `access_token` is faulty. Now it will skip it and move onto the next access token.